### PR TITLE
Archivos de config para que use el certificado https en aws

### DIFF
--- a/deployment/assembly/aws-eb.xml
+++ b/deployment/assembly/aws-eb.xml
@@ -1,0 +1,20 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>aws-eb</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <files>
+        <file>
+            <source>${basedir}/target/${project.build.finalName}.jar</source>
+        </file>
+    </files>
+    <fileSets>
+        <fileSet>
+            <directory>${basedir}/deployment/aws</directory>
+            <outputDirectory>.ebextensions</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/deployment/aws/alb-http-to-https-redirection-full.config
+++ b/deployment/aws/alb-http-to-https-redirection-full.config
@@ -1,0 +1,53 @@
+####################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+####################################################################################################
+
+####################################################################################################
+#### This configuration file adds a listener to the Application Load Balancer for port 443, this new listener
+#### requires the ARN of a public website certificate create residing in the certificate manager service.
+#### The configuration file also modifies the default port 80 listener attached to an Application Load Balancer
+#### to automatically redirect incoming connections on HTTP to HTTPS.
+#### This will not work with an environment using the load balancer type Classic or Network.
+#### Do not use this configuration file if a listener has already been created for port 443 from the console.
+####################################################################################################
+
+Resources:
+  AWSEBV2LoadBalancerListener:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: '443'
+            Host: '#{host}'
+            Path: '/#{path}'
+            Query: '#{query}'
+            StatusCode: HTTP_301
+      LoadBalancerArn:
+        Ref: AWSEBV2LoadBalancer
+      Port: 80
+      Protocol: HTTP
+  AWSEBV2LoadBalancerListenerHTTPS:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      Certificates:
+        - CertificateArn: arn:aws:acm:us-east-1:346215801426:certificate/dbfcd08a-88aa-4e53-82c6-5972b3d960f2
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn:
+            Ref: AWSEBV2LoadBalancerTargetGroup
+      LoadBalancerArn:
+        Ref: AWSEBV2LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+

--- a/deployment/aws/nginx/conf.d/proxy.conf
+++ b/deployment/aws/nginx/conf.d/proxy.conf
@@ -1,0 +1,5 @@
+client_max_body_size 15M;
+proxy_connect_timeout 10s;
+proxy_send_timeout 60s;
+proxy_read_timeout 60s;
+send_timeout 60s;

--- a/deployment/aws/timezone.config
+++ b/deployment/aws/timezone.config
@@ -1,0 +1,3 @@
+commands:
+  set_time_zone:
+    command: ln -f -s /usr/share/zoneinfo/America/Argentina/Buenos_Aires /etc/localtime

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.jonybuzz</groupId>
     <artifactId>encontralo</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <name>Encontralo</name>
     <description>Web para reunir dueños con mascotas perdidas</description>
     <url>https://github.com/jonybuzz/encontralo</url>
@@ -308,6 +308,25 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.9.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>deployment/assembly/aws-eb.xml</descriptor>
+                    </descriptors>
+                    <finalName>${project.artifactId}-${project.version}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assembly-for-aws-eb</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -10076,6 +10076,9 @@
       "version": "2.40.0",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "fsevents": "~2.3.1"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12640,6 +12643,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -13302,6 +13306,7 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {


### PR DESCRIPTION
Redirige el puerto 80 al 443, aumenta límite de subida al nginx y setea zona horaria Argentina

Resolves #22 